### PR TITLE
add missing #include<optional>

### DIFF
--- a/src/spirv/spirv_module.h
+++ b/src/spirv/spirv_module.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_set>
+#include <optional>
 
 #include "spirv_code_buffer.h"
 #include "spirv_compression.h"


### PR DESCRIPTION
I wasn't able to compile DXVK (applying the diff between rbernon/spirv-compile-time and doitsujin/master as a patch) without adding this. Not a C++ dev, so I'm not sure if the include is missing or if my system is messed up - could you check on this? Thanks!